### PR TITLE
Fixes #85, toggling enabled no longer crashes the game

### DIFF
--- a/src/main/java/com/minenash/customhud/mixin/MinecraftClientMixin.java
+++ b/src/main/java/com/minenash/customhud/mixin/MinecraftClientMixin.java
@@ -45,6 +45,9 @@ public abstract class MinecraftClientMixin {
 
     @Redirect(method = "render", at = @At(value = "FIELD", target = "Lnet/minecraft/client/option/GameOptions;debugEnabled:Z"))
     public boolean getGpuUsageAndOtherPerformanceMetrics(GameOptions instance) {
+        if (CustomHud.getActiveProfile() == null) {
+            return false;
+        }
         return CustomHud.getActiveProfile().enabled.performanceMetrics || instance.debugEnabled;
     }
 


### PR DESCRIPTION
Small fix to the enable toggle crash. Just adds a check for if `CustomHud.getActiveProfile()` is `null`, and if it is, returns `getGpuUsageAndOtherPerformanceMetrics` as false.

Seems to fix the issue.