### PR TITLE
Fix crash with Sodium 0.5

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,7 +52,8 @@ dependencies {
 
 	implementation "org.joml:joml:1.10.2" //sodium
 	modImplementation "org.anarres:jcpp:1.4.14" //iris
-	modImplementation "io.github.douira:glsl-transformer:2.0.0-pre9" //iris
+	modImplementation "io.github.douira:glsl-transformer:2.0.0-pre13" //iris
+	modImplementation "org.antlr:antlr4-runtime:4.11.1" //iris
 
 	// PSA: Some older mods, compiled on Loom 0.2.1, might have outdated Maven POMs.
 	// You may need to force-disable transitiveness on them.

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,18 +3,18 @@ org.gradle.jvmargs=-Xmx4G
 
 # Fabric Properties
 	# check these on https://fabricmc.net/develop
-	minecraft_version=1.20
-	yarn_mappings=1.20+build.1
+	minecraft_version=1.20.1
+	yarn_mappings=1.20.1+build.10
 	loader_version=0.14.21
 
 # Mod Properties
-	mod_version = 3.1.0+1.20
+	mod_version = 3.2.0+1.20.1
 	maven_group = com.minenash
 	archives_base_name = custom_hud
 
 # Dependencies
 	#Fabric api
-	fabric_version=0.83.0+1.20
+	fabric_version=0.83.0+1.20.1
 	modmenu_version=7.0.1
-	sodium_version=mc1.20-0.4.10
-	iris_version=1.6.4+1.20
+	sodium_version=mc1.20.1-0.5.0
+	iris_version=1.6.5+1.20.1

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,5 +16,5 @@ org.gradle.jvmargs=-Xmx4G
 	#Fabric api
 	fabric_version=0.83.0+1.20.1
 	modmenu_version=7.0.1
-	sodium_version=mc1.20.1-0.5.0
-	iris_version=1.6.5+1.20.1
+	sodium_version=mc1.20.1-0.5.2
+	iris_version=1.6.8+1.20.1

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ org.gradle.jvmargs=-Xmx4G
 	loader_version=0.14.21
 
 # Mod Properties
-	mod_version = 3.2.0+1.20.1
+	mod_version = 3.1.1+1.20.1
 	maven_group = com.minenash
 	archives_base_name = custom_hud
 

--- a/src/main/java/com/minenash/customhud/mod_compat/SodiumCompat.java
+++ b/src/main/java/com/minenash/customhud/mod_compat/SodiumCompat.java
@@ -16,7 +16,6 @@ public class SodiumCompat {
     private static List<String> debugLines;
 
     public static final Supplier<String> VERSION = SodiumClientMod::getVersion;
-    public static final Supplier<String> CHUNK_ARENA_ALLOCATOR = () -> SodiumClientMod.options().advanced.arenaMemoryAllocator.name();
     public static final Supplier<String> STAGING_BUFFER = () -> debugLines.get(3).substring(16);
 
     public static final Supplier<String> BUFFER_OBJECTS = () -> debugLines.get(1).substring(23);
@@ -26,7 +25,6 @@ public class SodiumCompat {
     public static void registerCompat() {
 
         registerElement("sodium_version", (_str) -> new StringSupplierElement(VERSION));
-        registerElement("sodium_chunk_arena_allocator", (_str) -> new StringSupplierElement(CHUNK_ARENA_ALLOCATOR));
         registerElement("sodium_staging_buffers", (_str) -> new StringSupplierElement(STAGING_BUFFER));
 
         registerElement("sodium_buffer_objects", (_str) -> new StringIntSupplierElement(BUFFER_OBJECTS));
@@ -36,7 +34,7 @@ public class SodiumCompat {
         registerComplexData(() -> {
             SodiumWorldRenderer renderer = SodiumWorldRenderer.instanceNullable();
             if (renderer != null)
-                debugLines = (List<String>) renderer.getMemoryDebugStrings();
+                debugLines = (List<String>) renderer.getDebugStrings();
         });
 
     }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -30,6 +30,6 @@
   "depends": {
     "fabricloader": ">=0.12.12",
     "fabric": "*",
-    "minecraft": ">=1.20- <1.20.2-"
+    "minecraft": ">=1.20.1- <1.20.2-"
   }
 }


### PR DESCRIPTION
Update to 1.20.1 only as Sodium 0.5 only supports 1.20.1
also the allocator setting doesn't exist anymore

Fixes #102 