### PR TITLE
Potential Fix for Missing/Bad/Weird GPU-Names on Linux

### DIFF
--- a/src/main/java/com/minenash/customhud/HudElements/supplier/StringSupplierElement.java
+++ b/src/main/java/com/minenash/customhud/HudElements/supplier/StringSupplierElement.java
@@ -10,6 +10,7 @@ import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.resource.language.I18n;
 import net.minecraft.entity.Entity;
 import net.minecraft.registry.Registries;
+import net.minecraft.util.Util;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Direction;
 import net.minecraft.world.biome.source.util.VanillaBiomeParameters;
@@ -57,7 +58,7 @@ public class StringSupplierElement implements HudElement {
 
     public static final Supplier<String> JAVA_VERSION = () -> System.getProperty("java.version");
     public static final Supplier<String> CPU_NAME = () -> ComplexData.cpu.getProcessorIdentifier().getName();
-    public static final Supplier<String> GPU_NAME = () -> GlDebugInfo.getRenderer().substring(0, GlDebugInfo.getRenderer().indexOf('/'));
+    public static final Supplier<String> GPU_NAME = () -> (Util.getOperatingSystem() == Util.OperatingSystem.WINDOWS ? GlDebugInfo.getRenderer() : GlDebugInfo.getRenderer().substring(0, GlDebugInfo.getRenderer().indexOf("("))).trim();
 
     public static final Supplier<String> MUSIC_ID = () -> MusicAndRecordTracker.isMusicPlaying ? MusicAndRecordTracker.musicId : null;
     public static final Supplier<String> MUSIC_NAME = () -> MusicAndRecordTracker.isMusicPlaying ? MusicAndRecordTracker.musicName : null;


### PR DESCRIPTION
This should potentially fix the gpu-name being shown incorrectly, or not at all.

I tested this on both Linux and Windows (11) with an RX 6900XT and a 6600XT.
I do not own an Intel or Nvidia-GPU, but i'd blindly assume they should work the same way. Maybe this can be tested by someone who does own one.