### PR TITLE
Hide CustomHUD under certain conditions for better clarity

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,6 +46,9 @@ dependencies {
 		exclude module: "fabric-api"
 	}
 
+	modCompileOnly "dev.emi:emi-fabric:${emi_version}:api"
+	modLocalRuntime "dev.emi:emi-fabric:${emi_version}"
+
 //	implementation include("com.fifesoft:rsyntaxtextarea:3.3.3")
 //	implementation include("com.formdev:flatlaf:3.1.1")
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,3 +16,4 @@ org.gradle.jvmargs=-Xmx4G
 	#Fabric api
 	fabric_version=0.91.1+1.20.4
 	modmenu_version=9.0.0
+	emi_version=1.1.6+1.20.4

--- a/src/main/java/com/minenash/customhud/render/CustomHudRenderer.java
+++ b/src/main/java/com/minenash/customhud/render/CustomHudRenderer.java
@@ -14,6 +14,8 @@ import com.minenash.customhud.data.HudTheme;
 import com.minenash.customhud.data.Profile;
 import com.minenash.customhud.data.Section;
 import com.mojang.blaze3d.systems.RenderSystem;
+import dev.emi.emi.api.EmiApi;
+import net.fabricmc.loader.api.FabricLoader;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.gui.DrawContext;
 import net.minecraft.client.gui.screen.ChatScreen;
@@ -35,8 +37,12 @@ public class CustomHudRenderer {
     public static void render(DrawContext context, float tickDelta) {
 
         Profile profile = ProfileManager.getActive();
-        if (profile == null || client.getDebugHud().shouldShowDebugHud())
+        if (profile == null || client.getDebugHud().shouldShowDebugHud() || client.options.hudHidden)
             return;
+
+        if (FabricLoader.getInstance().isModLoaded("emi"))
+            if (EmiApi.getHandledScreen() != null)
+                return;
 
         if (profile.baseTheme.getTargetGuiScale() != client.getWindow().getScaleFactor())
             client.onResolutionChanged();


### PR DESCRIPTION
CustomHUD is now hidden when:
- The entire HUD is hidden using the F1 key
- The EMI screen is open